### PR TITLE
AddingPowerSupport_CI/Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ jobs:
     arch: ppc64le
   - go: 1.3
     arch: ppc64le
+  - go: tip
+    arch:ppc64le
+    
 
 script:
     - go test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,18 @@ go:
     - 1.2
     - 1.3
     - tip
-exclude:
-  jobs:
-    - go: 1.0
-      arch: ppc64le
-    - go: 1.1
-      arch: ppc64le
-    - go: 1.2
-      arch: ppc64le
-    - go: 1.3
-      arch: ppc64le
+
+jobs:
+ exclude:
+ exclude:
+  - go: 1.0
+    arch: ppc64le
+  - go: 1.1
+    arch: ppc64le
+  - go: 1.2
+    arch: ppc64le
+  - go: 1.3
+    arch: ppc64le
 
 script:
     - go test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,25 +4,10 @@ arch:
 language: go
 
 go:
-    - 1.0
-    - 1.1
-    - 1.2
-    - 1.3
+    - 1.13
+    - 1.14
+    - 1.15
     - tip
-
-jobs:
- exclude:
- exclude:
-  - go: 1.0
-    arch: ppc64le
-  - go: 1.1
-    arch: ppc64le
-  - go: 1.2
-    arch: ppc64le
-  - go: 1.3
-    arch: ppc64le
-  - go: tip
-    arch:ppc64le
     
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch: 
+    - ppc64le
+    - amd64
 language: go
 
 go:
@@ -6,6 +9,16 @@ go:
     - 1.2
     - 1.3
     - tip
+exclude:
+  jobs:
+    - go: 1.0
+      arch: ppc64le
+    - go: 1.1
+      arch: ppc64le
+    - go: 1.2
+      arch: ppc64le
+    - go: 1.3
+      arch: ppc64le
 
 script:
     - go test


### PR DESCRIPTION
Adding power support ppc64le with Continues Integration/testing so that code remains architecture independent.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

The build is successful on both arch: amd64/ppc64le, please find the Travis Link below.
https://travis-ci.com/github/santosh653/colorstring

Please let me know if you need any further details? or if I am missing any.

Thank You !!